### PR TITLE
Feature/19 add lifecycle management module for game sessions

### DIFF
--- a/src/main/java/io/cavia/trader/TraderApplication.java
+++ b/src/main/java/io/cavia/trader/TraderApplication.java
@@ -2,8 +2,10 @@ package io.cavia.trader;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TraderApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/io/cavia/trader/module/client/config/WebClientConfig.java
+++ b/src/main/java/io/cavia/trader/module/client/config/WebClientConfig.java
@@ -4,6 +4,7 @@ import io.cavia.trader.module.client.connector.RestWebClientImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
@@ -16,7 +17,15 @@ public class WebClientConfig {
 
     @Bean
     public WebClient webClient() {
+        // 대용량 문자열을 디코딩 하기 위해 WebClient의 응답 버퍼 사이즈 10mb로 설정
         return webClientBuilder
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(configurer -> configur
+                                .defaultCodecs()
+                                .maxInMemorySize(10 * 1024 * 1024)
+                        )
+                        .build()
+                )
                 .baseUrl(baseUrl)
                 .build();
     }

--- a/src/main/java/io/cavia/trader/module/client/config/WebClientConfig.java
+++ b/src/main/java/io/cavia/trader/module/client/config/WebClientConfig.java
@@ -20,7 +20,7 @@ public class WebClientConfig {
         // 대용량 문자열을 디코딩 하기 위해 WebClient의 응답 버퍼 사이즈 10mb로 설정
         return webClientBuilder
                 .exchangeStrategies(ExchangeStrategies.builder()
-                        .codecs(configurer -> configur
+                        .codecs(configurer -> configurer
                                 .defaultCodecs()
                                 .maxInMemorySize(10 * 1024 * 1024)
                         )

--- a/src/main/java/io/cavia/trader/module/game/dto/Game.java
+++ b/src/main/java/io/cavia/trader/module/game/dto/Game.java
@@ -1,4 +1,4 @@
-package io.cavia.trader.module.game.service.dto;
+package io.cavia.trader.module.game.dto;
 
 import io.cavia.trader.module.client.dto.QuotesOutput;
 import io.cavia.trader.module.client.dto.TradesOutput;

--- a/src/main/java/io/cavia/trader/module/game/service/GameAdministrationService.java
+++ b/src/main/java/io/cavia/trader/module/game/service/GameAdministrationService.java
@@ -1,6 +1,9 @@
 package io.cavia.trader.module.game.service;
 
+import io.cavia.trader.module.game.dto.Game;
+
 public interface GameAdministrationService {
 
-    void createGame();
+    Game createGame();
+    int getMinutesBetween(Game game);
 }

--- a/src/main/java/io/cavia/trader/module/game/service/GameAdministrationServiceImpl.java
+++ b/src/main/java/io/cavia/trader/module/game/service/GameAdministrationServiceImpl.java
@@ -26,7 +26,9 @@ public class GameAdministrationServiceImpl implements GameAdministrationService 
         Game game = new Game();
 
         game.setStockId(stocks
-                .get((int) (Math.floor(Math.random() * (stocks.size() - 1))))
+                .get(
+                        (int)(Math.random() * stocks.size())
+                )
                 .getId()
         );
 
@@ -60,7 +62,7 @@ public class GameAdministrationServiceImpl implements GameAdministrationService 
     public int getMinutesBetween(Game game) {
 
         // 현재 시간과 게임 시작 시간의 차이
-        int MinutesBetween = (int) (
+        int minutesBetween = (int) (
                 LocalDateTime.now()
                         .atZone(ZoneId.systemDefault())
                         .toInstant()
@@ -71,13 +73,13 @@ public class GameAdministrationServiceImpl implements GameAdministrationService 
                         .toEpochMilli());
 
         // 시간이 0이면 바로 리턴
-        if (MinutesBetween == 0) return MinutesBetween;
+        if (minutesBetween == 0) return minutesBetween;
 
         // 밀리세컨드 단위 오차 제거
-        MinutesBetween = MinutesBetween % (1000 * 60) == 0 ?
-                MinutesBetween / (1000 * 60)
-                : MinutesBetween / (1000 * 60) + 1;
+        minutesBetween = minutesBetween % (1000 * 60) == 0 ?
+                minutesBetween / (1000 * 60)
+                : minutesBetween / (1000 * 60) + 1;
 
-        return MinutesBetween;
+        return minutesBetween;
     }
 }

--- a/src/main/java/io/cavia/trader/module/game/service/GameAdministrationServiceImpl.java
+++ b/src/main/java/io/cavia/trader/module/game/service/GameAdministrationServiceImpl.java
@@ -2,31 +2,33 @@ package io.cavia.trader.module.game.service;
 
 import io.cavia.trader.module.client.connector.RestWebClientImpl;
 import io.cavia.trader.module.client.dto.StocksOutput;
-import io.cavia.trader.module.game.service.dto.Game;
+import io.cavia.trader.module.game.dto.Game;
 import jakarta.websocket.Session;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayDeque;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
-@Component
+@Service
 @RequiredArgsConstructor
 public class GameAdministrationServiceImpl implements GameAdministrationService {
 
     private final RestWebClientImpl restWebClient;
 
     private List<StocksOutput> stocks;
-    private ArrayDeque<Game> games;
 
     @Override
-    public void createGame() {
+    public Game createGame() {
         if (stocks == null) setStocks();
         Game game = new Game();
 
-        game.setStockId((int) (Math.floor(Math.random() * (stocks.size()-1))));
+        game.setStockId(stocks
+                .get((int) (Math.floor(Math.random() * (stocks.size() - 1))))
+                .getId()
+        );
 
         game.setTrades(restWebClient
                 .getTrades(game.getStockId())
@@ -43,12 +45,39 @@ public class GameAdministrationServiceImpl implements GameAdministrationService 
         game.setChatSessions(new ConcurrentHashMap<Integer, Session>());
         game.setChartSessions(new ConcurrentHashMap<Integer, Session>());
         game.setStartedAt(LocalDateTime.now());
+
+        return game;
     }
 
-    public void setStocks(){
+
+    public void setStocks() {
         this.stocks = restWebClient
                 .getStocks()
                 .block()
                 .getOutput();
+    }
+
+    public int getMinutesBetween(Game game) {
+
+        // 현재 시간과 게임 시작 시간의 차이
+        int MinutesBetween = (int) (
+                LocalDateTime.now()
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant()
+                        .toEpochMilli()
+                        - game.getStartedAt()
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant()
+                        .toEpochMilli());
+
+        // 시간이 0이면 바로 리턴
+        if (MinutesBetween == 0) return MinutesBetween;
+
+        // 밀리세컨드 단위 오차 제거
+        MinutesBetween = MinutesBetween % (1000 * 60) == 0 ?
+                MinutesBetween / (1000 * 60)
+                : MinutesBetween / (1000 * 60) + 1;
+
+        return MinutesBetween;
     }
 }

--- a/src/main/java/io/cavia/trader/module/game/service/GameManager.java
+++ b/src/main/java/io/cavia/trader/module/game/service/GameManager.java
@@ -1,4 +1,6 @@
 package io.cavia.trader.module.game.service;
 
 public interface GameManager {
+
+    void managementGameSessionsLifeCycle();
 }

--- a/src/main/java/io/cavia/trader/module/game/service/GameManager.java
+++ b/src/main/java/io/cavia/trader/module/game/service/GameManager.java
@@ -1,0 +1,4 @@
+package io.cavia.trader.module.game.service;
+
+public interface GameManager {
+}

--- a/src/main/java/io/cavia/trader/module/game/service/GameManagerImpl.java
+++ b/src/main/java/io/cavia/trader/module/game/service/GameManagerImpl.java
@@ -23,10 +23,10 @@ public class GameManagerImpl implements GameManager {
 
         if (!games.isEmpty()) {
             // 현재시간 - 세션시작 시간을 분 단위로 치환한 값
-            int MinutesBetween = gameAdministrationService.getMinutesBetween(games.peekFirst());
+            int minutesBetween = gameAdministrationService.getMinutesBetween(games.peekFirst());
 
             // 세션의 생명 주기가 끝났으면 선입 세션 삭제
-            if (MinutesBetween >= GAME_LIFE_CYCLE) {
+            if (minutesBetween >= GAME_LIFE_CYCLE) {
                 // TODO 게임 세션 삭제 전 DB 저장 필요
                 games.removeFirst();
                 System.out.println("Game Session Closed, Games size: " + games.size());

--- a/src/main/java/io/cavia/trader/module/game/service/GameManagerImpl.java
+++ b/src/main/java/io/cavia/trader/module/game/service/GameManagerImpl.java
@@ -1,4 +1,8 @@
 package io.cavia.trader.module.game.service;
 
-public class GameManagerImpl {
+public class GameManagerImpl implements GameManager {
+    @Override
+    public void managementGameSessionsLifeCycle() {
+
+    }
 }

--- a/src/main/java/io/cavia/trader/module/game/service/GameManagerImpl.java
+++ b/src/main/java/io/cavia/trader/module/game/service/GameManagerImpl.java
@@ -1,8 +1,41 @@
 package io.cavia.trader.module.game.service;
 
+import io.cavia.trader.module.game.dto.Game;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayDeque;
+
+@Component
+@RequiredArgsConstructor
 public class GameManagerImpl implements GameManager {
+
+    private final GameAdministrationService gameAdministrationService;
+    private final int GAME_LIFE_CYCLE = 30;
+    private ArrayDeque<Game> games = new ArrayDeque<>();
+
+    @Scheduled(cron = "0 0/10 * * * *")
     @Override
     public void managementGameSessionsLifeCycle() {
 
+        if (!games.isEmpty()) {
+            // 현재시간 - 세션시작 시간을 분 단위로 치환한 값
+            int MinutesBetween = gameAdministrationService.getMinutesBetween(games.peekFirst());
+
+            // 세션의 생명 주기가 끝났으면 선입 세션 삭제
+            if (MinutesBetween >= GAME_LIFE_CYCLE) {
+                // TODO 게임 세션 삭제 전 DB 저장 필요
+                games.removeFirst();
+                System.out.println("Game Session Closed, Games size: " + games.size());
+            }
+        }
+
+        // 게임 세션 1개 생성
+        games.add(gameAdministrationService.createGame());
+        System.out.println("Game Session Created, Games size: " + games.size());
     }
+
 }

--- a/src/main/java/io/cavia/trader/module/game/service/GameManagerImpl.java
+++ b/src/main/java/io/cavia/trader/module/game/service/GameManagerImpl.java
@@ -1,0 +1,4 @@
+package io.cavia.trader.module.game.service;
+
+public class GameManagerImpl {
+}

--- a/src/test/java/io/cavia/trader/TraderApplicationTests.java
+++ b/src/test/java/io/cavia/trader/TraderApplicationTests.java
@@ -1,13 +1,19 @@
 package io.cavia.trader;
 
+import io.cavia.trader.module.game.service.GameAdministrationService;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class TraderApplicationTests {
 
+	@Autowired
+	private GameAdministrationService gameAdministrationService;
+
 	@Test
 	void contextLoads() {
+		gameAdministrationService.createGame();
 	}
 
 }


### PR DESCRIPTION
1. 게임 세션을 관리하는 매니저 모듈을 생성했습니다
* 현재 세션 시간의 라이프 사이클은 30분 세션간 간격은 10분으로 설정되어 있습니다
              ㄴ 세션 라이프사이클과 시간 간격 변경을 고려해 라이프사이클 / 시간 간격 대신 
                  직접 밀리세컨드 값을 비교해 라이프 사이클을 검사하고 있습니다

* 현재 생성된 게임(세션)DTO에는
stockID = 종목 id
Quotes = 호가 집계 데이터
Trades = 체결 집계 데이터
chartSession = 차트 웹소켓 세션의 집합
chatSession = 채팅 웹소켓 세션의 집합
startedAt = 게임 생성 시간
필드의 실제 데이터가 존재합니다.
