### PR TITLE
로그인 컨트롤러와 뷰 추가

### DIFF
--- a/src/main/java/io/cavia/trader/module/member/controller/LoginController.java
+++ b/src/main/java/io/cavia/trader/module/member/controller/LoginController.java
@@ -1,0 +1,4 @@
+package io.cavia.trader.module.member.controller;
+
+public class LoginController {
+}

--- a/src/main/java/io/cavia/trader/module/member/controller/LoginController.java
+++ b/src/main/java/io/cavia/trader/module/member/controller/LoginController.java
@@ -1,4 +1,19 @@
 package io.cavia.trader.module.member.controller;
 
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
 public class LoginController {
+
+    @GetMapping("/login")
+    public String showLoginForm() {
+        return "member/login";
+    }
+
+    @GetMapping("/reset-password")
+    public String showEmailForm() {
+        return "member/reset-password/email";
+    }
+
 }

--- a/src/main/java/io/cavia/trader/module/member/controller/SignupController.java
+++ b/src/main/java/io/cavia/trader/module/member/controller/SignupController.java
@@ -23,8 +23,14 @@ public class SignupController {
         return new SignupForm();
     }
 
+    @GetMapping
+    public String moveToSignupProcess() {
+        return "redirect:/signup/terms";
+    }
+
     @GetMapping("/terms")
     public String showTermsForm() {
+
         //TODO: 약관 파일을 불러와 넣어줘야함
         return "member/signup/terms";
     }
@@ -122,7 +128,7 @@ public class SignupController {
      */
     @PostMapping("/password")
     public String processPassword(@ModelAttribute("signupForm")
-                                  @Validated(SignupForm.ValidationGroups.PasswordGroup.class) SignupForm signupForm,
+                                  @Validated(SignupForm.ValidationGroups.SignupGroup.class) SignupForm signupForm,
                                   BindingResult bindingResult) {
 
         if (signupForm.getPassword() != null && signupForm.getPasswordConfirm() != null

--- a/src/main/java/io/cavia/trader/module/member/controller/SignupForm.java
+++ b/src/main/java/io/cavia/trader/module/member/controller/SignupForm.java
@@ -18,16 +18,19 @@ public class SignupForm {
         public interface TermsGroup {
         }
 
-        public interface EmailGroup extends TermsGroup{
+        public interface EmailGroup {
         }
 
-        public interface AuthKeyGroup extends EmailGroup{
+        public interface AuthKeyGroup {
         }
 
-        public interface NicknameGroup extends AuthKeyGroup{
+        public interface NicknameGroup {
         }
 
-        public interface PasswordGroup extends NicknameGroup{
+        public interface PasswordGroup {
+        }
+
+        public interface SignupGroup extends TermsGroup, EmailGroup, AuthKeyGroup, NicknameGroup, PasswordGroup {
         }
     }
 

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -1,10 +1,61 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
+    <meta charset="UTF-8">
+    <title>로그인</title>
 </head>
 <body>
-$END$
+
+<div class="container">
+
+    <div class="logo-area">
+        <a href="/">
+            <img src="/images/logo.png" alt="서비스 로고">
+        </a>
+    </div>
+
+    <div class="login-title">
+        <h2>로그인</h2>
+    </div>
+    <div class="login-content">
+        <p></p>
+    </div>
+
+    <form th:action="@{/login}" method="post">
+        <div>
+            <input type="email" id="email" name="email" placeholder="이메일을 입력하세요" required/>
+
+            <div th:if="${#fields.hasErrors('email')}" style="color:red;">
+                <p th:text="${#fields.errors('email')[0]}"></p>
+            </div>
+        </div>
+
+        <div>
+            <input type="password" id="password" name="password" required/>
+
+            <div th:if="${#fields.hasErrors('password')}" style="color:red;">
+                <p th:text="${#fields.errors('password')[0]}"></p>
+            </div>
+        </div>
+
+        <div th:if="${#fields.hasGlobalErrors()}" style="color:red;">
+            <p th:text="${#fields.globalErrors()[0]}"></p>
+        </div>
+
+        <div class="submit-area">
+            <button type="submit">로그인</button>
+        </div>
+
+        <div>
+            <a th:href="@{/signup}">회원 등록하기</a>
+        </div>
+        <div>
+            <a th:href="@{/reset-password}">비밀번호를 잊으셨나요?</a>
+        </div>
+
+    </form>
+
+</div>
+
 </body>
 </html>

--- a/src/main/resources/templates/member/reset-password/email.html
+++ b/src/main/resources/templates/member/reset-password/email.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>비밀번호 재설정 - 이메일 인증</title>
+</head>
+<body>
+
+<div class="container">
+
+    <div class="logo-area">
+        <a href="/">
+            <img src="/images/logo.png" alt="서비스 로고">
+        </a>
+    </div>
+
+    <div class="reset-password-title">
+        <h2>이메일 인증</h2>
+    </div>
+    <div class="reset-password-content">
+        <p>회원가입된 이메일을 입력해주세요. 인증 메일이 발송됩니다.</p>
+    </div>
+
+    <form th:action="@{/signup/email}" th:object="${signupForm}" method="post">
+
+        <input type="email" id="email" name="email" maxlength="254"
+               th:field="*{email}" placeholder="yourname@example.com" required>
+
+        <div th:if="${#fields.hasErrors('email')}" style="color:red;">
+            <p th:text="${#fields.errors('email')[0]}"></p>
+        </div>
+
+        <div class="submit-area">
+            <button type="submit">인증 메일 보내기</button>
+        </div>
+
+    </form>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
1. 로그인, 비밀번호 재설정 뷰 추가
2. 로그인, 비밀번호 재설정 컨트롤러 추가
3. 비밀번호 재설정 컨트롤러에서 SignupForm 클래스의 검증을 재사용하기 위해 
SignupForm 클래스의 검증 그룹을 수정함. SignupController 에서도 검증 로직을 변경했지만, 결과적으로는 동일한 로직이 작동하게함