### PR TITLE
Featuer/35 mypage nickname update

### DIFF
--- a/src/main/java/io/cavia/trader/module/member/mypage/controller/RestMyPageController.java
+++ b/src/main/java/io/cavia/trader/module/member/mypage/controller/RestMyPageController.java
@@ -2,14 +2,14 @@ package io.cavia.trader.module.member.mypage.controller;
 
 import io.cavia.trader.module.member.entity.Member;
 import io.cavia.trader.module.member.mypage.dto.GameParticipationDto;
+import io.cavia.trader.module.member.mypage.dto.NicknameUpdateRequestDto;
 import io.cavia.trader.module.member.mypage.service.MyPageService;
+import io.cavia.trader.module.member.service.SignupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -18,14 +18,27 @@ import java.util.List;
 public class RestMyPageController {
 
     private final MyPageService mypageService;
+    private final SignupService signupService;
 
     @GetMapping("/member-id/{memberId}")
-    public ResponseEntity<List<GameParticipationDto>> getGameParticipationsByMemberId(@PathVariable int memberId){
+    public ResponseEntity<List<GameParticipationDto>> getGameParticipationsByMemberId(@PathVariable int memberId) {
         return ResponseEntity.status(200).body(mypageService.findByMemberId(memberId));
     }
-    @GetMapping("/id/{id}")
-    public ResponseEntity<Member> getMembersByEmail(@PathVariable Long id){
-        return ResponseEntity.status(200).body(mypageService.findById(id));
 
+    @GetMapping("/id/{id}")
+    public ResponseEntity<Member> getMembersByEmail(@PathVariable Long id) {
+        return ResponseEntity.status(200).body(mypageService.findById(id));
+    }
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<String> getcheckNickname(@RequestParam String nickname){
+        signupService.validateDuplicateNickname(nickname);
+        return  ResponseEntity.status(200).body("중복없음");
+    }
+
+    @PatchMapping("/nickname")
+    public ResponseEntity<String> updateNickname(@RequestBody NicknameUpdateRequestDto nicknameUpdateRequestDto) {
+        mypageService.changeNickname(nicknameUpdateRequestDto.getId(),nicknameUpdateRequestDto.getNickname(),LocalDateTime.now());
+        return  ResponseEntity.status(200).body("변경성공");
     }
 }

--- a/src/main/java/io/cavia/trader/module/member/mypage/controller/ViewMyPageController.java
+++ b/src/main/java/io/cavia/trader/module/member/mypage/controller/ViewMyPageController.java
@@ -14,4 +14,8 @@ public class ViewMyPageController {
     public String myPage(){
         return "member/mypage/mypage-main";
     }
+    @GetMapping("/nickname-edit")
+    public String nicknameUpdate(){
+        return "member/mypage/nickname-edit";
+    }
 }

--- a/src/main/java/io/cavia/trader/module/member/mypage/dto/NicknameUpdateRequestDto.java
+++ b/src/main/java/io/cavia/trader/module/member/mypage/dto/NicknameUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package io.cavia.trader.module.member.mypage.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class NicknameUpdateRequestDto {
+    private Long id;
+    private String nickname;
+}

--- a/src/main/java/io/cavia/trader/module/member/mypage/service/MyPageService.java
+++ b/src/main/java/io/cavia/trader/module/member/mypage/service/MyPageService.java
@@ -3,10 +3,12 @@ package io.cavia.trader.module.member.mypage.service;
 import io.cavia.trader.module.member.entity.Member;
 import io.cavia.trader.module.member.mypage.dto.GameParticipationDto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MyPageService {
 
     public List<GameParticipationDto> findByMemberId(int memberId);
     public Member findById(Long id);
+    public void changeNickname(Long id, String nickname, LocalDateTime nicknameUpdatedAt);
 }

--- a/src/main/java/io/cavia/trader/module/member/mypage/service/MyPageServiceImpl.java
+++ b/src/main/java/io/cavia/trader/module/member/mypage/service/MyPageServiceImpl.java
@@ -4,10 +4,12 @@ import io.cavia.trader.module.member.entity.Member;
 import io.cavia.trader.module.member.mypage.dto.GameParticipationDto;
 import io.cavia.trader.module.member.mypage.mapper.MyPageMapper;
 import io.cavia.trader.module.member.repository.MemberMapper;
+import io.cavia.trader.module.notice.exception.InvalidNoticeRequestException;
 import io.cavia.trader.module.notice.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,6 +39,14 @@ public class MyPageServiceImpl implements MyPageService {
             throw new NotFoundException("사용자가 존재하지 않습니다");
         }
         return member;
+    }
+
+    @Override
+    public void changeNickname(Long id, String nickname, LocalDateTime nicknameUpdatedAt) {
+        int result = memberMapper.updateNickname(id,nickname,nicknameUpdatedAt);
+        if(result<=0){
+            throw new InvalidNoticeRequestException("닉네임 변경 실패");
+        }
     }
 
 }

--- a/src/main/java/io/cavia/trader/module/member/repository/MemberMapper.java
+++ b/src/main/java/io/cavia/trader/module/member/repository/MemberMapper.java
@@ -2,7 +2,9 @@ package io.cavia.trader.module.member.repository;
 
 import io.cavia.trader.module.member.entity.Member;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Mapper
@@ -29,6 +31,11 @@ public interface MemberMapper {
      * @return 조회된 회원 객체 (없을 경우 Optional.empty())
      */
     Optional<Member> findById(Long id);
+
+    /**
+     * 닉네임을 수정합니다.
+     */
+    int updateNickname(@Param("id") Long id, @Param("nickname") String nickname, @Param("nicknameUpdatedAt") LocalDateTime nicknameUpdatedAt);
 
     /**
      * 이메일이 이미 있는지 조회합니다.

--- a/src/main/java/io/cavia/trader/module/member/repository/MemberRepository.java
+++ b/src/main/java/io/cavia/trader/module/member/repository/MemberRepository.java
@@ -1,7 +1,9 @@
 package io.cavia.trader.module.member.repository;
 
 import io.cavia.trader.module.member.entity.Member;
+import org.apache.ibatis.annotations.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface MemberRepository {
@@ -20,6 +22,11 @@ public interface MemberRepository {
      * @return 조회된 회원 객체 (없을 경우 Optional.empty())
      */
     Optional<Member> findByEmail(String email);
+
+    /**
+     * 닉네임을 수정합니다.
+     */
+    int updateNickname(Long id, String nickname, LocalDateTime nicknameUpdatedAt);
 
     /**
      * 이메일이 이미 있는지 조회합니다.

--- a/src/main/java/io/cavia/trader/module/member/repository/MybatisMemberRepository.java
+++ b/src/main/java/io/cavia/trader/module/member/repository/MybatisMemberRepository.java
@@ -4,6 +4,7 @@ import io.cavia.trader.module.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -21,6 +22,9 @@ public class MybatisMemberRepository implements MemberRepository {
     public Optional<Member> findByEmail(String email) {
         return memberMapper.findByEmail(email);
     }
+
+    @Override
+    public int updateNickname(Long id, String nickname, LocalDateTime nicknameUpdatedAt) {return memberMapper.updateNickname(id,nickname,nicknameUpdatedAt);}
 
     @Override
     public boolean existsByEmail(String email) {

--- a/src/main/resources/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mapper/member/MemberMapper.xml
@@ -90,4 +90,15 @@
         SELECT EXISTS(SELECT 1 FROM members WHERE nickname = #{nickname})
     </select>
 
+    <!--nickname을 수정하는 UPDATE 쿼리입니다.-->
+    <update id="updateNickname">
+        UPDATE members
+        <set>
+            nickname = #{nickname},
+            nickname_updated_at = #{nicknameUpdatedAt}
+        </set>
+        WHERE
+        id = #{id}
+    </update>
+
 </mapper>

--- a/src/main/resources/templates/member/mypage/mypage-main.html
+++ b/src/main/resources/templates/member/mypage/mypage-main.html
@@ -16,7 +16,7 @@
         <!--닉네임 등급 자산조회 등등-->
         <strong>닉네임</strong> <span id="nickname"></span>
         <strong>등급</strong> <span id="total-score"></span><br>
-        <input type="button" value="닉네임변경"><input type="button" value="비밀번호변경"><br>
+        <input type="button" value="닉네임변경" onclick="location.href='nickname-edit'"><input type="button" value="비밀번호변경"><br>
         <h3>자산조회</h3> <span id="cash"></span><input type="button" value="자산초기화"><br>
     </div>
 </div>
@@ -53,7 +53,7 @@
             }
         }catch(err) {
             alert(err.message);
-        } 
+        }
     }
 </script>
 </body>

--- a/src/main/resources/templates/member/mypage/nickname-edit.html
+++ b/src/main/resources/templates/member/mypage/nickname-edit.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <script>
+        async function updateNickname(event){
+            event.preventDefault();
+
+            const id = 1; //추후 토큰으로 교체
+            const nickname = document.getElementById('nickname').value.trim();
+            const message = document.getElementById('message');
+            //닉네임 검증
+            if(!nickname){
+                message.innerText = '닉네임을 입력해주세요';
+                message.style.color = 'red';
+                return
+            }
+            try{
+                const checkRes = await fetch(`/api/mypage/check-nickname?nickname=${encodeURIComponent(nickname)}`);
+                //중복 검사
+                if(!checkRes.ok){
+                    message.innerText = '이미 사용중인 닉네임입니다';
+                    message.style.color = 'red';
+                    return;
+                }
+                //닉네임 변경
+                const res = await fetch('/api/mypage/nickname', {
+                    method: 'PATCH',
+                    headers: {
+                        'Content-type':'application/json'
+                    },
+                    body: JSON.stringify({
+                        id: id,
+                        nickname: nickname
+                    })
+                });
+                if(!res.ok){
+                    throw new Error('닉네임 변경에 실패했습니다.');
+                }
+
+                alert('닉네임 변경에 성공했습니다.');
+                location.href = '/member/mypage/mypage-main';
+            }catch (error){
+                message.innerText = error.message;
+                message.style.color = 'red';
+            }
+        }
+    </script>
+</head>
+<body>
+<h2>닉네임 변경</h2>
+<h3>변경할 닉네임을 올려주세요</h3>
+<form onsubmit="updateNickname(event)">
+    <input type="text" id="nickname" name="nickname" placeholder="닉네임을 입력해주세요">
+    <span id="message" style="display:block; margin-top:10px;">닉네임 피드백 메세지</span>
+    <input type="submit">
+</form>
+</body>
+</html>


### PR DESCRIPTION
1. JSON과 매핑하기 위해 NicknameUpdateRequestDto 생성
2. 중복 검사용 Get으로 컨트롤러 생성
3. 닉네임 변경 Patch로 컨트롤러 생성
4. SignupService에 닉네임 중복 검사 메소드 이용
5. 닉네임 변경 버튼을 누르면 페이지 이동을 위한 ViewMyPageController에 메소드 추가
6. id는 추후에 토큰 관련해서 변경예정