### PR TITLE
feat:메인페이지 css 폴더 생성.

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -1,0 +1,96 @@
+/*컨테이너를 연한 파랑색으로 감싸는 웨퍼*/
+.main-wrapper {
+  background-color: #eef4fb;
+  min-height: 100vh;
+  padding: 30px;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  max-width: 950px;
+  margin: 40px auto;
+}
+
+/*메인페이지 랭킹을 감싸는 컨테이너*/
+.main-container {
+  background-color: white;
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  max-width: 900px;
+  margin: 30px auto;
+}
+/*어떤 랭킹인지 알려주는 제목*/
+#message {
+  font-size: 24px;
+  font-weight: 600;
+  margin-bottom: 24px;
+  color: #333;
+}
+
+/*총 자산순, 총 점수 버튼*/
+#ranking button {
+  display: inline-block;
+  padding: 6px 12px;
+  margin-bottom: 8px;
+  border-radius: 6px;
+  border: 1px solid #ddd;
+  background-color: #f9f9f9;
+  color: #333;
+  text-decoration: none;
+}
+#ranking button:hover {
+  background-color: #007bff;
+  color: white;
+}
+/*랭킹 상단의 제목들 순위,닉네임,자산,점수*/
+.ranking-header {
+  display: grid;
+  grid-template-columns: 240px 240px 240px 240px;
+  column-gap: 16px;
+
+  font-size: 12px;
+  font-weight: 600;
+  margin-top: 16px;
+  margin-bottom: 8px;
+  color: gray;
+  padding-bottom: 20px;
+  border-bottom : 1px solid #e0e0e0;
+}
+
+/* 유저 행들을 감싸는 랭킹 리스트 컨테이너 */
+#rankingList {
+  display: flex;
+  flex-direction: column;
+}
+
+/* 각 유저 한 줄 (순위, 닉네임, 자산, 점수) */
+.ranking-row {
+  display: grid;
+  grid-template-columns: 240px 240px 240px 240px;
+  column-gap: 16px;
+
+  font-size: 12px;
+  font-weight: 600;
+  margin-top: 20px;
+  margin-bottom: 8px;
+  color: gray;
+  padding-bottom: 30px;
+  border-bottom : 1px solid #e0e0e0;
+}
+
+/*주식 게임 버튼*/
+.game-btn input[type="button"] {
+  display: block;
+  padding: 20px 48px;
+  margin: 0 auto;
+  margin-top: 8px;
+  margin-bottom: 8px;
+  border-radius: 6px;
+  border: 1px solid #ddd;
+  background-color: #f9f9f9;
+  color: #333;
+  text-decoration: none;
+}
+.game-btn input[type="button"]:hover {
+  background-color: #007bff;
+  color: white;
+}

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -3,19 +3,29 @@
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
+    <link rel="stylesheet" href="/css/main.css">
 </head>
 <body>
 <div th:replace="~{fragments/header :: header}"></div>
-
-<div id="message"></div>
-<div id="ranking">
-    <button onclick="loadRanking('cash')">총 자산순</button>
-    <button onclick="loadRanking('total-score')">점수순</button>
-    <div id="rankingList">
+<div class="main-wrapper">
+    <div class="main-container">
+        <div id="message"></div>
+        <div id="ranking">
+            <button onclick="loadRanking('cash')">총 자산순</button>
+            <button onclick="loadRanking('total-score')">점수순</button>
+            <div class="ranking-header">
+                <span class="col-rank">순위</span>
+                <span class="col-nickname">닉네임</span>
+                <span class="col-cash">자산</span>
+                <span class="col-score">점수</span>
+            </div>
+            <div id="rankingList">
+            </div>
+        </div>
+        <div class="game-btn">
+            <input type="button" value="주식게임" onclick="location.href = '/game'">
+        </div>
     </div>
-</div>
-<div>
-    <input type="button" value="주식게임" onclick="location.href = '/game'">
 </div>
 </body>
 <script src="/js/header.js"></script>
@@ -50,7 +60,12 @@
 
         rankings.forEach((user, i) => {
             const div = document.createElement('div');
-            div.innerText = `${i + 1}위 - ${user.nickname} | 자산: ${user.cash} | 점수: ${user.totalScore}`;
+            div.classList.add('ranking-row');
+            div.innerHTML = `
+              <span class="col-rank">${i + 1}위</span>
+              <span class="col-nickname">${user.nickname}</span>
+              <span class="col-cash">${Number(user.cash).toLocaleString()}원</span>
+              <span class="col-score">${user.totalScore}</span>`;
             list.appendChild(div);
         });
 


### PR DESCRIPTION
1. main 페이지 순위 닉네임 자산 점수가 원래 있던 js로 했을 경우 메인 초안처럼 나오는게 아니고 하나로 묶여서 나오길래 innerText 에서innerHTML 으로 수정해서 span을 사용해서 각 컬럼에 css를 추가하는 방식을 사용함
2. main 페이지에 각 순위 닉네임 자산 점수에 관련된 헤더 같은 부분을 추가했음
3. main 페이지에 전체를 감쌀 수 있는 div 태그 2개 main-container 랑 main-wrapper 추가했음
