### PR TITLE
auth, member의 rest컨트롤러들 리팩토링, 주석추가

### DIFF
--- a/src/main/java/io/cavia/trader/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/cavia/trader/common/exception/GlobalExceptionHandler.java
@@ -31,7 +31,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ApiResponse<?>> handleCustomException(ApiException e) {
 
         ErrorCode errorCode = e.getErrorCode();
-        log.warn("Business Exception Occurred: {}", errorCode.getMessage());
+        log.debug("Business Exception Occurred: {}", errorCode.getMessage());
 
         return ApiResponses.of(errorCode.getHttpStatus(), errorCode.getMessage());
     }

--- a/src/main/java/io/cavia/trader/module/auth/controller/AuthRestController.java
+++ b/src/main/java/io/cavia/trader/module/auth/controller/AuthRestController.java
@@ -27,6 +27,13 @@ public class AuthRestController {
 
     private final AuthService authService;
 
+    /**
+     * 사용자의 이메일과 비밀번호로 로그인을 시도하고, 성공 시 JWT를 발급합니다.
+     *
+     * @param requestDto 로그인에 필요한 이메일, 비밀번호를 담은 DTO
+     * @param response   JWT를 담을 응답 헤더
+     * @return 성공 메시지를 담은 ApiResponse
+     */
     @PostMapping("/api/auth/login")
     public ResponseEntity<ApiResponse<?>> login(@Valid @RequestBody LoginRequestDto requestDto,
                                                 HttpServletResponse response) {
@@ -36,10 +43,11 @@ public class AuthRestController {
     }
 
     /**
-     * 인증된 사용자의 모든 정보를 반환하는 API
+     * 현재 인증된 사용자의 상세 정보를 조회합니다.
+     * 현재 헤더.html의 닉네임 부분을 가져오고 있는 엔드포인트로, 원래대로라면 시큐리티 필터에서 잡아야 함
      *
-     * @param userDetails SecurityContextHolder에 저장된 인증 객체의 principal
-     * @return body: {data: userDetails.getMember()}
+     * @param userDetails SecurityContextHolder에 저장된 사용자 정보
+     * @return Member 엔티티를 data에 담은 ApiResponse
      */
     @GetMapping("api/auth/login-checker")
     public ResponseEntity<ApiResponse<?>> getMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -50,10 +58,10 @@ public class AuthRestController {
     }
 
     /**
-     * 입력된 이메일로 인증 메일을 발송함
+     * 이메일 인증을 위해 입력된 이메일로 인증 코드를 발송합니다.
      *
-     * @param requestDto 사용자가 입력한 이메일이 들어있는 dto
-     * @return 상태코드와 메시지
+     * @param requestDto 인증 코드를 받을 이메일 주소를 담은 DTO
+     * @return 200 OK 성공 응답
      */
     @PostMapping("/api/auth/verification/send-code")
     public ResponseEntity<ApiResponse<?>> sendVerificationEmail(@Valid @RequestBody SendCodeRequestDto requestDto) {
@@ -62,23 +70,22 @@ public class AuthRestController {
     }
 
     /**
-     * 인증 코드를 입력받아, 이메일과 인증 코드를 검증하고,
-     * 그 이메일의 회원가입 여부에 따라 참 거짓을 응답
+     * 이메일과 인증 코드를 검증합니다. (비밀번호 재설정 시 사용)
      *
-     * @param requestDto 사용자가 입력한 이메일과 인증코드가 들어있는 dto
-     * @return 상태코드, is-our-member : true/false
+     * @param requestDto 검증할 이메일과 인증 코드를 담은 DTO
+     * @return 200 OK 성공 응답
      */
     @PostMapping("/api/auth/verification/verify-code")
     public ResponseEntity<ApiResponse<?>> verifyPasswordResetVerification(@Valid @RequestBody VerifyCodeRequestDto requestDto) {
-        authService.verifyPasswordResetVerificationRequest(requestDto.getEmail(), requestDto.getAuthKey());
+        authService.verifyCodeForPasswordReset(requestDto.getEmail(), requestDto.getAuthKey());
         return ApiResponses.ok();
     }
 
     /**
-     * 완성된 requestDto를 가지고 비밀번호를 재설정함
+     * 인증된 이메일과 새 비밀번호로 비밀번호를 재설정합니다.
      *
-     * @param requestDto 사용자가 입력한 이메일, 인증코드, 비밀번호가 들어있는 dto
-     * @return 응답 body가 없는 204 no content 성공 응답
+     * @param requestDto 이메일, 인증 코드, 새 비밀번호를 담은 DTO
+     * @return 본문 없는 204 No Content 성공 응답
      */
     @PostMapping("/api/auth/password-reset")
     public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequestDto requestDto) {

--- a/src/main/java/io/cavia/trader/module/auth/controller/AuthRestController.java
+++ b/src/main/java/io/cavia/trader/module/auth/controller/AuthRestController.java
@@ -32,7 +32,7 @@ public class AuthRestController {
      *
      * @param requestDto 로그인에 필요한 이메일, 비밀번호를 담은 DTO
      * @param response   JWT를 담을 응답 헤더
-     * @return 성공 메시지를 담은 ApiResponse
+     * @return 성공 메시지를 담은 200 OK 응답
      */
     @PostMapping("/api/auth/login")
     public ResponseEntity<ApiResponse<?>> login(@Valid @RequestBody LoginRequestDto requestDto,
@@ -47,7 +47,7 @@ public class AuthRestController {
      * 현재 헤더.html의 닉네임 부분을 가져오고 있는 엔드포인트로, 원래대로라면 시큐리티 필터에서 잡아야 함
      *
      * @param userDetails SecurityContextHolder에 저장된 사용자 정보
-     * @return Member 엔티티를 data에 담은 ApiResponse
+     * @return Member 엔티티를 ApiResponse.data에 담은 200 OK 성공 응답
      */
     @GetMapping("api/auth/login-checker")
     public ResponseEntity<ApiResponse<?>> getMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -61,7 +61,7 @@ public class AuthRestController {
      * 이메일 인증을 위해 입력된 이메일로 인증 코드를 발송합니다.
      *
      * @param requestDto 인증 코드를 받을 이메일 주소를 담은 DTO
-     * @return 200 OK 성공 응답
+     * @return OK 메시지를 담은 200 OK 응답
      */
     @PostMapping("/api/auth/verification/send-code")
     public ResponseEntity<ApiResponse<?>> sendVerificationEmail(@Valid @RequestBody SendCodeRequestDto requestDto) {
@@ -73,7 +73,7 @@ public class AuthRestController {
      * 이메일과 인증 코드를 검증합니다. (비밀번호 재설정 시 사용)
      *
      * @param requestDto 검증할 이메일과 인증 코드를 담은 DTO
-     * @return 200 OK 성공 응답
+     * @return OK 메시지를 담은 200 OK 응답
      */
     @PostMapping("/api/auth/verification/verify-code")
     public ResponseEntity<ApiResponse<?>> verifyPasswordResetVerification(@Valid @RequestBody VerifyCodeRequestDto requestDto) {

--- a/src/main/java/io/cavia/trader/module/auth/controller/SignupController.java
+++ b/src/main/java/io/cavia/trader/module/auth/controller/SignupController.java
@@ -85,7 +85,7 @@ public class SignupController {
             return "members/signup/verify";
         }
         try {
-            authService.verifySignupVerificationRequest(signupDto.getEmail(), signupDto.getAuthKey());
+            authService.verifyCodeForSignup(signupDto.getEmail(), signupDto.getAuthKey());
         } catch (ApiException e) {
             bindingResult.rejectValue("authKey", "runtimeError", e.getErrorCode().getMessage());
             return "members/signup/verify";

--- a/src/main/java/io/cavia/trader/module/auth/service/AuthService.java
+++ b/src/main/java/io/cavia/trader/module/auth/service/AuthService.java
@@ -4,17 +4,60 @@ import io.cavia.trader.module.auth.dto.SignupDto;
 import io.cavia.trader.module.member.entity.Member;
 
 public interface AuthService {
+
+    /**
+     * 지정된 이메일 주소로 인증 코드가 담긴 메일을 발송합니다.
+     *
+     * @param email 인증 코드를 받을 이메일
+     */
     void sendVerificationEmail(String email);
 
-    void verifyPasswordResetVerificationRequest(String email, String authKey);
+    /**
+     * 비밀번호 재설정을 위해 이메일과 인증 코드를 검증합니다.
+     * @param email 사용자 이메일
+     * @param authKey 사용자가 입력한 인증 코드
+     */
+    void verifyCodeForPasswordReset(String email, String authKey);
 
-    void verifySignupVerificationRequest(String email, String authKey);
+    /**
+     * 회원가입을 위해 이메일과 인증 코드를 검증합니다.
+     * @param email 사용자 이메일
+     * @param authKey 사용자가 입력한 인증 코드
+     */
+    void verifyCodeForSignup(String email, String authKey);
 
+    /**
+     * 사용하려는 닉네임이 이미 존재하는지 검사합니다.
+     *
+     * @param nickname 중복 검사할 닉네임
+     * @throws io.cavia.trader.common.exception.ApiException 닉네임이 이미 존재할 경우
+     */
     void validateDuplicateNickname(String nickname);
 
+    /**
+     * 전달된 DTO의 정보로 최종 회원가입을 처리하고, 생성된 회원 정보를 반환합니다.
+     *
+     * @param signupDto 회원가입에 필요한 모든 정보가 담긴 DTO
+     * @return 생성된 Member 엔티티
+     */
     Member join(SignupDto signupDto);
 
+    /**
+     * 사용자의 이메일과 비밀번호를 받아 로그인을 수행합니다.
+     *
+     * @param email    로그인 시도 이메일
+     * @param password 로그인 시도 비밀번호
+     * @return 로그인 성공 시 발급된 JWT
+     * @throws io.cavia.trader.common.exception.ApiException 로그인 실패 시
+     */
     String login(String email, String password);
 
+    /**
+     * 이메일과 인증 코드로 사용자를 검증한 후, 새 비밀번호로 재설정합니다.
+     *
+     * @param email       사용자 이메일
+     * @param authKey     이메일로 발급된 인증 코드
+     * @param rawPassword 암호화되지 않은 새 비밀번호
+     */
     void resetPassword(String email, String authKey, String rawPassword);
 }

--- a/src/main/java/io/cavia/trader/module/auth/service/AuthServiceImpl.java
+++ b/src/main/java/io/cavia/trader/module/auth/service/AuthServiceImpl.java
@@ -41,13 +41,13 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public void verifyPasswordResetVerificationRequest(String email, String authKey) {
+    public void verifyCodeForPasswordReset(String email, String authKey) {
         verifyAuthKey(email, authKey);
         memberService.getMemberByEmail(email);
     }
 
     @Override
-    public void verifySignupVerificationRequest(String email, String authKey) {
+    public void verifyCodeForSignup(String email, String authKey) {
         verifyAuthKey(email, authKey);
         memberService.validateDuplicateEmail(email);
     }
@@ -86,13 +86,6 @@ public class AuthServiceImpl implements AuthService {
         return member;
     }
 
-    /**
-     * 로그인 비즈니스 로직
-     *
-     * @param email    로그인 시도 이메일
-     * @param password 로그인 시도 비밀번호
-     * @return 생성된 JWT
-     */
     @Override
     public String login(String email, String password) {
         try {
@@ -102,6 +95,13 @@ public class AuthServiceImpl implements AuthService {
         } catch (ApiException e) {
             throw new ApiException(ErrorCode.LOGIN_FAILED);
         }
+    }
+
+    @Override
+    public void resetPassword(String email, String authKey, String rawPassword) {
+        verifyAuthKey(email, authKey);
+        Member member = memberService.getMemberByEmail(email);
+        memberService.changePassword(member.getId(), rawPassword);
     }
 
     /**
@@ -118,12 +118,5 @@ public class AuthServiceImpl implements AuthService {
         String htmlBody = templateEngine.process("email/auth-email", context);
 
         emailService.sendEmail(to, "[TRADER.IO] 이메일 인증", htmlBody);
-    }
-
-    @Override
-    public void resetPassword(String email, String authKey, String rawPassword) {
-        verifyAuthKey(email, authKey);
-        Member member = memberService.getMemberByEmail(email);
-        memberService.changePassword(member.getId(), rawPassword);
     }
 }

--- a/src/main/java/io/cavia/trader/module/member/controller/MemberRestController.java
+++ b/src/main/java/io/cavia/trader/module/member/controller/MemberRestController.java
@@ -1,20 +1,17 @@
 package io.cavia.trader.module.member.controller;
 
+import io.cavia.trader.common.response.ApiResponse;
 import io.cavia.trader.common.response.ApiResponses;
 import io.cavia.trader.module.auth.security.UserDetailsImpl;
-import io.cavia.trader.module.member.entity.GameParticipation;
 import io.cavia.trader.module.member.dto.NicknameUpdateRequestDto;
 import io.cavia.trader.module.member.dto.PasswordChangeRequestDto;
 import io.cavia.trader.module.member.dto.PasswordVerificationRequestDto;
-import io.cavia.trader.module.member.entity.Member;
 import io.cavia.trader.module.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("api/members")
@@ -24,36 +21,32 @@ public class MemberRestController {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public ResponseEntity<Member> getMembersByEmail(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-
-        return ResponseEntity.status(200)
-                .body(memberService.getMemberById(userDetails.getMember().getId()));
+    public ResponseEntity<ApiResponse<?>> getMembersByEmail(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ApiResponses.ok(userDetails.getMember());
     }
 
     @DeleteMapping("/me")
-    public ResponseEntity<String> deleteMember(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                               @RequestBody PasswordVerificationRequestDto requestDto) {
+    public ResponseEntity<Void> deleteMember(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                             @RequestBody PasswordVerificationRequestDto requestDto) {
         memberService.withdrawMember(userDetails.getMember().getId(), requestDto.getCurrentPassword());
-        return ResponseEntity.status(200).body("회원 삭제완료");
+        return ApiResponses.noContent();
     }
 
     @GetMapping("/me/game-participations")
-    public ResponseEntity<List<GameParticipation>> getGameParticipationsByMemberId(
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ResponseEntity.status(200)
-                .body(memberService.getGameParticipationByMemberId(userDetails.getMember().getId()));
+    public ResponseEntity<ApiResponse<?>> getGameParticipations(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ApiResponses.ok(memberService.getGameParticipationByMemberId(userDetails.getMember().getId()));
     }
 
     @PostMapping("/me/password/verify")
-    public ResponseEntity<String> getcheckPassword(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                   @Valid @RequestBody PasswordVerificationRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<?>> verifyPassword(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                         @Valid @RequestBody PasswordVerificationRequestDto requestDto) {
         memberService.validatePassword(userDetails.getMember().getId(), requestDto.getCurrentPassword());
-        return ResponseEntity.status(200).body("비밀번호 일치함");
+        return ApiResponses.ok();
     }
 
     @PatchMapping("/me/password")
     public ResponseEntity<?> changePassword(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                 @Valid @RequestBody PasswordChangeRequestDto requestDto) {
+                                            @Valid @RequestBody PasswordChangeRequestDto requestDto) {
         memberService.processPasswordChangeRequest(userDetails.getMember().getId(),
                 requestDto.getCurrentPassword(),
                 requestDto.getNewPassword());
@@ -61,15 +54,15 @@ public class MemberRestController {
     }
 
     @PostMapping("/me/cash/reset")
-    public ResponseEntity<String> resetCash(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<Void> resetCash(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         memberService.resetCash(userDetails.getMember().getId());
-        return ResponseEntity.status(200).body("변경성공");
+        return ApiResponses.noContent();
     }
 
     @PatchMapping("/me/nickname")
-    public ResponseEntity<String> updateNickname(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                 @Valid @RequestBody NicknameUpdateRequestDto requestDto) {
+    public ResponseEntity<Void> updateNickname(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                               @Valid @RequestBody NicknameUpdateRequestDto requestDto) {
         memberService.changeNickname(userDetails.getMember().getId(), requestDto.getNickname());
-        return ResponseEntity.status(200).body("변경성공");
+        return ApiResponses.noContent();
     }
 }

--- a/src/main/java/io/cavia/trader/module/member/controller/MemberRestController.java
+++ b/src/main/java/io/cavia/trader/module/member/controller/MemberRestController.java
@@ -66,7 +66,7 @@ public class MemberRestController {
 
     @GetMapping("/me/game-participations/count")
     public ResponseEntity<ApiResponse<?>> getGameParticipationCount(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ApiResponses.ok(memberService.getCountByMemberId(userDetails.getMember().getId()));
+        return ApiResponses.ok(memberService.getGameParticipationCountByMemberId(userDetails.getMember().getId()));
 
     }
 

--- a/src/main/java/io/cavia/trader/module/member/controller/MemberRestController.java
+++ b/src/main/java/io/cavia/trader/module/member/controller/MemberRestController.java
@@ -20,11 +20,24 @@ public class MemberRestController {
 
     private final MemberService memberService;
 
+    /**
+     * 현재 로그인된 사용자의 상세 정보를 조회합니다.
+     *
+     * @param userDetails SecurityContextHolder에 저장된 사용자 정보
+     * @return Member 엔티티를 ApiResponse.data에 담은 200 OK 응답
+     */
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<?>> getMembersByEmail(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ApiResponses.ok(userDetails.getMember());
     }
 
+    /**
+     * 현재 로그인된 사용자의 회원 탈퇴를 처리합니다.
+     *
+     * @param userDetails SecurityContextHolder에 저장된 사용자 정보
+     * @param requestDto  현재 비밀번호 확인을 위한 DTO
+     * @return 본문 없는 204 No Content 응답
+     */
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteMember(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                              @RequestBody PasswordVerificationRequestDto requestDto) {
@@ -32,11 +45,24 @@ public class MemberRestController {
         return ApiResponses.noContent();
     }
 
+    /**
+     * 현재 로그인된 사용자의 모든 게임 참여 기록을 조회합니다.
+     *
+     * @param userDetails SecurityContextHolder에 저장된 사용자 정보
+     * @return 게임 참여 기록 리스트를 ApiResponse.data에 담은 200 OK 응답
+     */
     @GetMapping("/me/game-participations")
     public ResponseEntity<ApiResponse<?>> getGameParticipations(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ApiResponses.ok(memberService.getGameParticipationByMemberId(userDetails.getMember().getId()));
     }
 
+    /**
+     * 현재 로그인된 사용자의 비밀번호가 일치하는지 검증합니다.
+     *
+     * @param userDetails SecurityContextHolder에 저장된 사용자 정보
+     * @param requestDto  검증할 현재 비밀번호를 담은 DTO
+     * @return OK 메시지를 담은 200 OK 응답
+     */
     @PostMapping("/me/password/verify")
     public ResponseEntity<ApiResponse<?>> verifyPassword(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                          @Valid @RequestBody PasswordVerificationRequestDto requestDto) {
@@ -44,6 +70,13 @@ public class MemberRestController {
         return ApiResponses.ok();
     }
 
+    /**
+     * 현재 로그인된 사용자의 비밀번호를 입력받아 새로운 비밀번호로 변경합니다.
+     *
+     * @param userDetails SecurityContextHolder에 저장된 사용자 정보
+     * @param requestDto  현재 비밀번호와 새 비밀번호를 담은 DTO
+     * @return 본문 없는 204 No Content 응답
+     */
     @PatchMapping("/me/password")
     public ResponseEntity<?> changePassword(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                             @Valid @RequestBody PasswordChangeRequestDto requestDto) {
@@ -53,12 +86,25 @@ public class MemberRestController {
         return ApiResponses.noContent();
     }
 
+    /**
+     * 현재 로그인된 사용자의 보유 자산을 초기화합니다.
+     *
+     * @param userDetails SecurityContextHolder에 저장된 사용자 정보
+     * @return 본문 없는 204 No Content 응답
+     */
     @PostMapping("/me/cash/reset")
     public ResponseEntity<Void> resetCash(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         memberService.resetCash(userDetails.getMember().getId());
         return ApiResponses.noContent();
     }
 
+    /**
+     * 현재 로그인된 사용자의 닉네임을 변경합니다.
+     *
+     * @param userDetails SecurityContextHolder에 저장된 사용자 정보
+     * @param requestDto  변경할 새 닉네임을 담은 DTO
+     * @return 본문 없는 204 No Content 응답
+     */
     @PatchMapping("/me/nickname")
     public ResponseEntity<Void> updateNickname(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                @Valid @RequestBody NicknameUpdateRequestDto requestDto) {

--- a/src/main/java/io/cavia/trader/module/member/repository/GameParticipationMapper.java
+++ b/src/main/java/io/cavia/trader/module/member/repository/GameParticipationMapper.java
@@ -10,5 +10,5 @@ public interface GameParticipationMapper {
 
     List<GameParticipation> findByMemberId(Long memberId);
     List<GameParticipation> findByMemberIdWithPaging(Long memberId, int limit, int offset);
-    int countByMemberId(Long memberId);
+    Long countByMemberId(Long memberId);
 }

--- a/src/main/java/io/cavia/trader/module/member/repository/GameParticipationMybatisRepository.java
+++ b/src/main/java/io/cavia/trader/module/member/repository/GameParticipationMybatisRepository.java
@@ -23,7 +23,7 @@ public class GameParticipationMybatisRepository implements GameParticipationRepo
     }
 
     @Override
-    public int countByMemberId(Long memberId) {
+    public Long countByMemberId(Long memberId) {
         return gameParticipationMapper.countByMemberId(memberId);
     }
 }

--- a/src/main/java/io/cavia/trader/module/member/repository/GameParticipationRepository.java
+++ b/src/main/java/io/cavia/trader/module/member/repository/GameParticipationRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface GameParticipationRepository {
     List<GameParticipation> findByMemberId(Long memberId);
     List<GameParticipation> findByMemberIdWithPaging(Long memberId, int limit, int offset);
-    int countByMemberId(Long memberId);
+    Long countByMemberId(Long memberId);
 }

--- a/src/main/java/io/cavia/trader/module/member/service/MemberService.java
+++ b/src/main/java/io/cavia/trader/module/member/service/MemberService.java
@@ -8,32 +8,123 @@ import java.util.List;
 
 public interface MemberService {
 
+    /**
+     * 특정 회원의 모든 게임 참여 기록을 조회합니다.
+     *
+     * @param memberId 조회할 회원의 ID
+     * @return 해당 회원의 게임 참여 기록 리스트
+     */
     List<GameParticipation> getGameParticipationByMemberId(Long memberId);
 
+    /**
+     * 회원 ID로 특정 회원 정보를 조회합니다.
+     *
+     * @param id 조회할 회원의 ID
+     * @return 조회된 Member 엔티티
+     * @throws io.cavia.trader.common.exception.ApiException 회원을 찾을 수 없을 경우
+     */
     Member getMemberById(Long id);
 
+    /**
+     * 이메일로 특정 회원 정보를 조회합니다.
+     *
+     * @param email 조회할 회원의 이메일
+     * @return 조회된 Member 엔티티
+     * @throws io.cavia.trader.common.exception.ApiException 회원을 찾을 수 없을 경우
+     */
     Member getMemberByEmail(String email);
 
+    /**
+     * 특정 회원의 닉네임을 변경합니다.
+     *
+     * @param id       변경할 회원의 ID
+     * @param nickname 새로운 닉네임
+     * @throws io.cavia.trader.common.exception.ApiException 닉네임이 이미 존재할 경우
+     */
     void changeNickname(Long id, String nickname);
 
+    /**
+     * 현재 사용자의 비밀번호가 일치하는지 검증합니다. (UI/UX 검증용)
+     *
+     * @param id       검증할 회원의 ID
+     * @param password 검증할 현재 비밀번호
+     * @throws io.cavia.trader.common.exception.ApiException 비밀번호가 일치하지 않을 경우
+     */
     void validatePassword(Long id, String password);
 
+    /**
+     * 로그인된 사용자가 현재 비밀번호를 인증한 후, 새 비밀번호로 변경합니다.
+     *
+     * @param id              변경할 회원의 ID
+     * @param currentPassword 확인을 위한 현재 비밀번호
+     * @param newPassword     변경할 새 비밀번호
+     * @throws io.cavia.trader.common.exception.ApiException 현재 비밀번호가 일치하지 않을 경우
+     */
     void processPasswordChangeRequest(Long id, String currentPassword, String newPassword);
 
+    /**
+     * 이메일 인증 등 다른 방법으로 본인 인증을 마친 사용자의 비밀번호를 재설정합니다.
+     * (추가적인 비밀번호 검증 과정 없기 때문에 주의)
+     *
+     * @param id          변경할 회원의 ID
+     * @param newPassword 재설정할 새 비밀번호
+     */
     void changePassword(Long id, String newPassword);
 
+    /**
+     * 특정 회원의 보유 자산을 초기화합니다.
+     *
+     * @param id 초기화할 회원의 ID
+     */
     void resetCash(Long id);
 
+    /**
+     * 특정 회원의 탈퇴를 처리합니다.
+     *
+     * @param id       탈퇴할 회원의 ID
+     * @param password 본인 확인을 위한 현재 비밀번호
+     */
     void withdrawMember(Long id, String password);
 
+    /**
+     * 회원가입 시, 사용하려는 이메일이 이미 존재하는지 검사합니다.
+     *
+     * @param email 중복 검사할 이메일
+     * @throws io.cavia.trader.common.exception.ApiException 이메일이 이미 존재할 경우
+     */
     void validateDuplicateEmail(String email);
 
+    /**
+     * 회원가입 시, 사용하려는 닉네임이 이미 존재하는지 검사합니다.
+     *
+     * @param nickname 중복 검사할 닉네임
+     * @throws io.cavia.trader.common.exception.ApiException 닉네임이 이미 존재할 경우
+     */
     void validateDuplicateNickname(String nickname);
 
+    /**
+     * 새로운 회원 정보를 DB에 저장합니다.
+     *
+     * @param member 저장할 Member 엔티티
+     */
     void createMember(Member member);
 
+    /**
+     * 보유 자산 순으로 전체 회원의 랭킹을 조회합니다.
+     *
+     * @param limit  조회할 개수
+     * @param offset 조회를 시작할 위치
+     * @return 랭킹 DTO 리스트
+     */
     List<UserRankingDto> findAllOrderByCash(Long limit, Long offset);
 
+    /**
+     * 누적 점수 순으로 전체 회원의 랭킹을 조회합니다.
+     *
+     * @param limit  조회할 개수
+     * @param offset 조회를 시작할 위치
+     * @return 랭킹 DTO 리스트
+     */
     List<UserRankingDto> findAllOrderByTotalScore(Long limit, Long offset);
 
 }

--- a/src/main/java/io/cavia/trader/module/member/service/MemberService.java
+++ b/src/main/java/io/cavia/trader/module/member/service/MemberService.java
@@ -18,7 +18,7 @@ public interface MemberService {
 
     List<GameParticipation> getGameParticipationByMemberIdWithPaging(Long memberId, int limit, int offset);
 
-    int getCountByMemberId(Long memberId);
+    Long getGameParticipationCountByMemberId(Long memberId);
 
     /**
      * 회원 ID로 특정 회원 정보를 조회합니다.

--- a/src/main/java/io/cavia/trader/module/member/service/MemberServiceImpl.java
+++ b/src/main/java/io/cavia/trader/module/member/service/MemberServiceImpl.java
@@ -47,7 +47,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public int getCountByMemberId(Long memberId) {
+    public Long getGameParticipationCountByMemberId(Long memberId) {
         return gameParticipationRepository.countByMemberId(memberId);
     }
 

--- a/src/main/resources/mapper/mypage/GameParticipationMapper.xml
+++ b/src/main/resources/mapper/mypage/GameParticipationMapper.xml
@@ -42,7 +42,7 @@
     <!--
        회원이 참여한 게임 전체 기록에 개수를 가져오는 쿼리 입니다.
     -->
-    <select id="countByMemberId" resultType="int">
+    <select id="countByMemberId" resultType="Long">
         SELECT count(*)
         FROM game_participations
         WHERE member_id = #{memberId}

--- a/src/main/resources/static/js/member/password-change.js
+++ b/src/main/resources/static/js/member/password-change.js
@@ -104,12 +104,7 @@ formStep2.addEventListener('submit', async (e) => {
             window.location.href = '/members/me';
         } else {
             const errorData = await response.json();
-            // @Valid에서 발생한 에러의 경우, 상세 에러 메시지를 표시
-            if (errorData.errors && errorData.errors.length > 0) {
-                step2Message.textContent = errorData.errors[0].reason;
-            } else {
-                step2Message.textContent = errorData.message || '비밀번호 변경에 실패했습니다.';
-            }
+            step2Message.textContent = errorData.message || '비밀번호 변경에 실패했습니다.';
         }
     } catch (error) {
         step2Message.textContent = '오류가 발생했습니다. 다시 시도해주세요.';

--- a/src/main/resources/static/js/member/password-reset.js
+++ b/src/main/resources/static/js/member/password-reset.js
@@ -47,9 +47,9 @@ formStep1.addEventListener('submit', (e) => {
         // 응답이 성공(2xx)이 아니면 에러를 발생시켜 .catch()로 넘깁니다.
         if (!response.ok) {
             // 서버가 보낸 에러 메시지를 얻기 위해 response.json()을 시도합니다.
-            return response.json().then(errorData => {
+            return response.json().then(body => {
                 // 실제 에러 객체를 만들어서 구체적인 에러 메시지를 전달합니다.
-                throw new Error(errorData.message || '알 수 없는 오류로 이메일 발송에 실패했습니다.');
+                throw new Error(body.message || '알 수 없는 오류로 이메일 발송에 실패했습니다.');
             });
         }
         // 성공 시에는 아무것도 할 필요가 없습니다. 사용자는 이미 다음 단계에 있습니다.
@@ -89,7 +89,7 @@ formStep2.addEventListener('submit', (e) => {
     .then(response => {
         if (!response.ok) {
             return response.json().then(body => {
-                throw new Error(body.message || '비밀번호 변경에 실패했습니다.');
+                throw new Error(body.message || '인증에 오류가 발생했습니다.');
             });
         }
         return response.json();

--- a/src/main/resources/templates/members/me/main.html
+++ b/src/main/resources/templates/members/me/main.html
@@ -69,7 +69,8 @@
                     'Authorization': 'Bearer ' + token
                 }
             });
-            totalCount = await countRes.json();
+            const countResBody = await countRes.json();
+            const totalCount = countResBody.data;
 
             await loadMoreGameParticipation();
         }catch(err) {
@@ -85,9 +86,12 @@
                 headers: {
                     'Authorization': 'Bearer ' + token
                     }
-                });
-            if(!res2.ok) throw new Error('게임 기록을 불러오지 못했습니다');
-            const gameParticipation = await res2.json();
+            });
+            const res2Body = await res2.json();
+            if(!res2.ok) {
+                throw new Error(res2Body.message || '게임 기록을 불러오지 못했습니다');
+            }
+            const gameParticipation = res2Body.data;
             const list = document.getElementById('gameDTO-list');
             if(gameParticipation.length === 0 && offset === 0 ) {
                 list.innerHTML = '<li>참여한 게임이 없습니다.</li>'

--- a/src/main/resources/templates/members/me/main.html
+++ b/src/main/resources/templates/members/me/main.html
@@ -52,7 +52,8 @@
             });
             if(!res1.ok) throw new Error('회원 정보를 불러오지 못했습니다');
             setupLogout();
-            const member = await res1.json();
+            const responseBody = await res1.json();
+            const member = responseBody.data;
             document.getElementById('nickname').innerText = member.nickname;
             document.getElementById('cash').innerText = member.cash;
             document.getElementById('total-score').innerText = member.totalScore;

--- a/src/main/resources/templates/members/me/main.html
+++ b/src/main/resources/templates/members/me/main.html
@@ -70,7 +70,7 @@
                 }
             });
             const countResBody = await countRes.json();
-            const totalCount = countResBody.data;
+            totalCount = countResBody.data;
 
             await loadMoreGameParticipation();
         }catch(err) {

--- a/src/main/resources/templates/members/me/nickname-change.html
+++ b/src/main/resources/templates/members/me/nickname-change.html
@@ -34,8 +34,10 @@
                         nickname: nickname
                     })
                 });
+
                 if(!res.ok){
-                    throw new Error('닉네임 변경에 실패했습니다.');
+                    const errorData = await res.json();
+                    throw new Error(errorData.message ||'닉네임 변경에 실패했습니다.');
                 }
                 alert('닉네임 변경에 성공했습니다.');
                 location.href = '/members/me';


### PR DESCRIPTION
1. 컨트롤러 메서드들과 서비스 인터페이스에 주석 추가
2. 컨트롤러에 ApiResponse 를 이용해서 공통된 형식의 응답을 할 수 있게 함. 
3. js에서도 ApiResponse 를 이용해서 공통된 응답을 처리할 수 있게 함.

객체는 data에 들어감. 

정상작동일때 예시)
{
    "status": 200,
    "message": "OK",
    "data": null
}
혹은
{
    "status": 200,
    "message": "OK",
    "data": {
        "nickname": "김범희바보"
        "password": "12341234"
    }
}

401, 403 (시큐리티가 자동으로 만든 예외 응답) 를 제외한 GlobalExceptionHandler가 만든 예외 응답 예시)
{
    "status": 400,
    "message": "비밀번호는 8자 이상 64자 이하로 입력해주세요",
    "data": null
}

그래서 js에서도 마찬가지로
const responseBody = await response.json(); // 여기서 json()은 비동기 방식으로 json body를 파싱해서 반환함.
const nickname = responseBody.data.nickname;
이나, 오류메시지를 쓰고 싶을 경우
const errorMessage = responseBody.message;
를 쓰면 됨.
