### PR TITLE
헤더에서 닉네임 불러올 때, 권한이 필요한 api/members/me 엔드포인트를 사용하게 함

### DIFF
--- a/src/main/java/io/cavia/trader/module/auth/controller/AuthRestController.java
+++ b/src/main/java/io/cavia/trader/module/auth/controller/AuthRestController.java
@@ -51,9 +51,6 @@ public class AuthRestController {
      */
     @GetMapping("api/auth/login-checker")
     public ResponseEntity<ApiResponse<?>> getMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        if (userDetails == null) {
-            throw new ApiException(ErrorCode.LOGIN_FAILED);
-        }
         return ApiResponses.ok(userDetails.getMember());
     }
 

--- a/src/main/java/io/cavia/trader/module/jwt/JwtUtil.java
+++ b/src/main/java/io/cavia/trader/module/jwt/JwtUtil.java
@@ -88,7 +88,7 @@ public class JwtUtil {
         } catch (SecurityException | MalformedJwtException e) {
             log.warn("유효하지 않은 JWT 서명입니다.", e);
         } catch (ExpiredJwtException e) {
-            log.warn("만료된 JWT 토큰입니다.");
+            log.debug("만료된 JWT 토큰입니다.");
         } catch (UnsupportedJwtException e) {
             log.warn("지원되지 않는 JWT 토큰입니다.", e);
         } catch (IllegalArgumentException e) {

--- a/src/main/resources/static/js/header.js
+++ b/src/main/resources/static/js/header.js
@@ -17,7 +17,7 @@
         }
 
         // 토큰이 존재하면, 서버에 '내 정보 조회' API를 호출하여 토큰의 유효성을 검증합니다.
-        fetch('/api/auth/login-checker', { // ❗️ 내 정보 조회 API 경로
+        fetch('/api/members/me', {
             method: 'GET',
             headers: {
                 'Authorization': 'Bearer ' + token
@@ -35,7 +35,7 @@
         })
         .then(body => {
             const userInfo = body.data;
-            // ❗️ API 호출 성공 시: 로그인 상태 UI를 표시합니다.
+            // API 호출 성공 시: 로그인 상태 UI를 표시합니다.
             // 서버로부터 받은 최신 닉네임 정보를 사용합니다.
             console.log(userInfo);
             console.log(userInfo.nickname);
@@ -45,11 +45,11 @@
             authenticatedHeader.style.display = 'flex';
         })
         .catch(error => {
-            // ❗️ API 호출 실패 시 (네트워크 에러, 401 등): 로그아웃 상태로 처리합니다.
+            // API 호출 실패 시 (네트워크 에러, 401 등): 로그아웃 상태로 처리합니다.
             console.error('로그인 상태 확인 실패:', error.message);
 
             // 유효하지 않은 토큰은 즉시 삭제합니다.
-//            localStorage.removeItem('jwt-token');
+            localStorage.removeItem('jwt-token');
 
             anonymousHeader.style.display = 'block';
             authenticatedHeader.style.display = 'none';

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -7,7 +7,7 @@
 <body>
 <footer class="site-footer">
   <div class="footer-container">
-    <p>서울특별시 마포구 월드컵북로 21 풍성빌딩 2층 | &copy; 2025 trader.io. All rights reserved. | 팀장: 이민석 | 조원 : 김범희 , 김동민 </p>
+    <p>서울특별시 마포구 월드컵북로  | &copy; 2025 trader.io, TEAM CAVIA. All rights reserved. </p>
   </div>
 </footer>
 </body>


### PR DESCRIPTION
1. 현재까지 권한이 필요없는 api/auth/login-checker를 사용했음
2. 그로인해 예외 분기도 생기고, 일관성이 깨짐.
3. api/members/me 엔드포인트를 사용하게 변경